### PR TITLE
Use regexp to extract fields from ls command's output in order to ignore unexpected extra characters from the shell

### DIFF
--- a/internal/scout/scout.go
+++ b/internal/scout/scout.go
@@ -27,11 +27,12 @@ type Scout struct {
 	localFile string
 	remote    *RemoteFile
 	bar       *progressbar.ProgressBar
+	verbose   bool
 }
 
 var LsOutputRegexp = regexp.MustCompile(`(-|d)([-rwx]{9})\s+(\d+)\s+(\w+)\s+(\w+)\s+(\d+)\s+([A-Za-z]+\s+\d+\s+\d{2}:\d{2})`)
 
-func New(source, target string) (*Scout, error) {
+func New(source, target string, verboseFlag bool) (*Scout, error) {
 	_, err := os.Stat(source)
 	if err != nil {
 		return nil, errorx.Decorate(err, "source file does not exist")
@@ -45,6 +46,7 @@ func New(source, target string) (*Scout, error) {
 	s := &Scout{
 		localFile: source,
 		remote:    remote,
+		verbose:   verboseFlag,
 	}
 
 	// Add the target filename if only target directory is specified
@@ -64,6 +66,7 @@ func (s *Scout) newClient() (*telnet.TelnetClient, error) {
 		Address:  s.remote.Host,
 		Login:    s.remote.Username,
 		Password: s.remote.Password,
+		Verbose:  s.verbose,
 	}
 
 	if errDial := tc.Dial(); errDial != nil {

--- a/main.go
+++ b/main.go
@@ -8,8 +8,10 @@ import (
 )
 
 func main() {
-	if len(os.Args) != 3 {
-		fmt.Println("Usage:   ./busyscout local_file remote_path")
+	argsCount := len(os.Args)
+
+	if argsCount < 3 || argsCount > 4 || argsCount == 4 && os.Args[3] != "--verbose" {
+		fmt.Println("Usage:   ./busyscout local_file remote_path [--verbose]")
 		fmt.Println("Example: ./busyscout ipwiz.zip root:12345@192.168.10.18:/tmp")
 		os.Exit(0)
 	}
@@ -18,7 +20,9 @@ func main() {
 	sourceFile := os.Args[1]
 	targetFile := os.Args[2]
 
-	s, errNew := scout.New(sourceFile, targetFile)
+	verboseFlag := argsCount == 4 && os.Args[3] == "--verbose"
+
+	s, errNew := scout.New(sourceFile, targetFile, verboseFlag)
 	if errNew != nil {
 		klog.Fatal(errNew)
 	}


### PR DESCRIPTION
This pull request aims to fix the [issue 2](https://github.com/krabiswabbie/busyscout/issues/2).
It added 2 commits:
- Use regexp to extract fields from ls command's output in order to ignore unexpected extra characters from the shell.
- Add command line option "--verbose".